### PR TITLE
feat: change to use dmypy as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,26 +30,28 @@ To use the built-in installation feature, execute the following command.
 
 ## Note
 
-### Initial Diagnostic Display
+### Use "dmypy" or "mypy"
+
+The `microsoft/vscode-mypy language server` uses `dmypy` by default. If you want to use `mypy`, set `mypy-type-checker.useDmypy` to `false`.
+
+**coc-settings.json**:
+
+```jsonc
+{
+  "mypy-type-checker.useDmypy": false
+}
+```
+
+### Initial Diagnostic Display (use mypy)
 
 The `mypy` command takes time to complete execution if the cache file for `mypy` does not exist. In other words, the first time it is executed, it takes time.
 
 The same is true if you are using a language server, so it will take some time to display the initial diagnostics.
 
-### [Warning] Known issues when using `dmypy` daemon mode
-
-The current default for `microsoft/vscode-mypy's langauge server` is to use `dmypy`, but `coc-mypy` uses `mypy`.
-
-It is possible to use `dmypy` in `coc-mypy` as well by setting `mypy-type-checker.useDmypy` to `true`.
-
-However, if `coc-mypy` is using `dmypy`, there is a problem that the `dmypy` daemon process remains after exiting Vim/Neovim...
-
-The `dmypy` process is located in the OS temporary directory and can be released by rebooting the OS. Alternatively, you can find the `dmypy` process yourself and kill it.
-
 ## Configuration options
 
 - `mypy-type-checker.enable`: Enable coc-mypy extension, default: `true`
-- `mypy-type-checker.useDmypy`: [Experimental]: Use dmypy deamon mode as the linting command run by microsoft/vscode-mypy's language server, default: `false`
+- `mypy-type-checker.useDmypy`: Use dmypy deamon mode as the linting command run by microsoft/vscode-mypy's language server, default: `true`
 - `mypy-type-checker.builtin.pythonPath`: Python 3.x path (Absolute path) to be used for built-in install, default: `""`
 - `mypy-type-checker.showDocumantaion.enable`: Whether to display the code action for open the Mypy rule documentation web page included in the diagnostic information, default: `true`
 

--- a/package.json
+++ b/package.json
@@ -88,8 +88,8 @@
         },
         "mypy-type-checker.useDmypy": {
           "type": "boolean",
-          "default": false,
-          "description": "[Experimental]: Use dmypy deamon mode as the linting command run by microsoft/vscode-mypy's language server."
+          "default": true,
+          "description": "Use dmypy deamon mode as the linting command run by microsoft/vscode-mypy's language server."
         },
         "mypy-type-checker.builtin.pythonPath": {
           "type": "string",

--- a/src/client.ts
+++ b/src/client.ts
@@ -33,7 +33,7 @@ type ImportStrategy = 'fromEnvironment' | 'useBundled';
 type Severity = 'Error' | 'Hint' | 'Information' | 'Warning';
 type ShowNotifications = 'off' | 'onError' | 'onWarning' | 'always';
 
-type MypyLspInitializationOptions = {
+type ExtensionInitializationOptions = {
   globalSettings: {
     args: string[];
     path: string[];
@@ -47,7 +47,7 @@ type MypyLspInitializationOptions = {
 function convertFromWorkspaceConfigToInitializationOptions() {
   const settings = workspace.getConfiguration(EXTENSION_NS);
 
-  const initializationOptions = <MypyLspInitializationOptions>{
+  const initializationOptions = <ExtensionInitializationOptions>{
     globalSettings: {
       args: settings.get('args'),
       path: settings.get('path'),
@@ -67,15 +67,11 @@ function getInitializationOptions(context: ExtensionContext) {
 
   // **MEMO**:
   //
-  // The current default for microsoft/vscode-mypy's langauge server is to use
-  // dmypy. However, there seems to be a problem with using dmypy with coc-mypy,
-  // where the daemon process remains after exiting Vim/Neovim...
+  // The current default for microsoft/vscode-mypy's langauge server is to use dmypy.
   //
   // microsoft/vscode-mypy's langauge server uses mypy by specifying the mypy
   // command path in the `mypy-type-checker.path` configuration.
-  //
-  // In coc-mypy, the mypy command is adjusted to be used by default.
-  if (!workspace.getConfiguration(EXTENSION_NS).get<boolean>('useDmypy', false)) {
+  if (!workspace.getConfiguration(EXTENSION_NS).get<boolean>('useDmypy', true)) {
     if (initializationOptions.globalSettings.path.length === 0) {
       const envMypyCommandPath = which.sync('mypy', { nothrow: true });
       if (envMypyCommandPath) {


### PR DESCRIPTION
The language server of microsoft/vscode-mypy terminates the dmypy process when the language server is stopped.

- <https://github.com/microsoft/vscode-mypy/blob/87491cf9576c9c9f428ca6468cdc448b94a08f32/bundled/tool/lsp_server.py#L285-L291>

Unfortunately, "deactivate" by coc.nvim does not address this issue and the dmypy process remains...

To handle this, we directly set the `VimLeavePre` event to terminate the language server. Also changed to use dmypy by default in coc-mypy as this solved the problem