### PR TITLE
refactor!: changed default to not use dmypy

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,22 +32,6 @@ To use the built-in installation feature, execute the following command.
 
 ## Note
 
-### Use "dmypy" or "mypy"
-
-The `microsoft/vscode-mypy language server` uses `dmypy` by default. If you want to use `mypy`, set `mypy-type-checker.useDmypy` to `false`.
-
-**coc-settings.json**:
-
-```jsonc
-{
-  "mypy-type-checker.useDmypy": false
-}
-```
-
-### [Use dmypy] Vim/Neovim will exit a little slower
-
-If you are using `dmypy`, the process of killing the dmypy process is included when Vim/Neovim exits. This may slow down the Vim/Neovim exit process slightly.
-
 ### [Use mypy] Initial Diagnostic Display
 
 The `mypy` command takes time to complete execution if the cache file for `mypy` does not exist. In other words, the first time it is executed, it takes time.
@@ -57,7 +41,6 @@ The same is true if you are using a language server, so it will take some time t
 ## Configuration options
 
 - `mypy-type-checker.enable`: Enable coc-mypy extension, default: `true`
-- `mypy-type-checker.useDmypy`: Use dmypy deamon mode as the linting command run by microsoft/vscode-mypy's language server, default: `true`
 - `mypy-type-checker.builtin.pythonPath`: Python 3.x path (Absolute path) to be used for built-in install, default: `""`
 - `mypy-type-checker.showDocumantaion.enable`: Whether to display the code action for open the Mypy rule documentation web page included in the diagnostic information, default: `true`
 - `mypy-type-checker.trace.server`: Traces the communication between coc.nvim and the language server, default: `"off"`

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
         },
         "mypy-type-checker.useDmypy": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "Use dmypy deamon mode as the linting command run by microsoft/vscode-mypy's language server."
         },
         "mypy-type-checker.builtin.pythonPath": {


### PR DESCRIPTION
I don't know if this is due to a change in options in mypy(dmypy) 1.4.x, 1.5.x or 1.6.x itself, but dmypy is not working properly on the language server itself.

Therefore, we have changed the default to use mypy instead of dmypy.