### PR TITLE
refactor!: changed default to use dmypy

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,22 @@ To use the built-in installation feature, execute the following command.
 
 ## Note
 
+### Use "dmypy" or "mypy"
+
+The `microsoft/vscode-mypy language server` uses `dmypy` by default. If you want to use `mypy`, set `mypy-type-checker.useDmypy` to `false`.
+
+**coc-settings.json**:
+
+```jsonc
+{
+  "mypy-type-checker.useDmypy": false
+}
+```
+
+### [Use dmypy] Vim/Neovim will exit a little slower
+
+If you are using `dmypy`, the process of killing the dmypy process is included when Vim/Neovim exits. This may slow down the Vim/Neovim exit process slightly.
+
 ### [Use mypy] Initial Diagnostic Display
 
 The `mypy` command takes time to complete execution if the cache file for `mypy` does not exist. In other words, the first time it is executed, it takes time.
@@ -41,6 +57,7 @@ The same is true if you are using a language server, so it will take some time t
 ## Configuration options
 
 - `mypy-type-checker.enable`: Enable coc-mypy extension, default: `true`
+- `mypy-type-checker.useDmypy`: Use dmypy deamon mode as the linting command run by microsoft/vscode-mypy's language server, default: `true`
 - `mypy-type-checker.builtin.pythonPath`: Python 3.x path (Absolute path) to be used for built-in install, default: `""`
 - `mypy-type-checker.showDocumantaion.enable`: Whether to display the code action for open the Mypy rule documentation web page included in the diagnostic information, default: `true`
 - `mypy-type-checker.trace.server`: Traces the communication between coc.nvim and the language server, default: `"off"`

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
         },
         "mypy-type-checker.useDmypy": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Use dmypy deamon mode as the linting command run by microsoft/vscode-mypy's language server."
         },
         "mypy-type-checker.builtin.pythonPath": {
@@ -141,7 +141,7 @@
           "type": "array"
         },
         "mypy-type-checker.importStrategy": {
-          "default": "useBundled",
+          "default": "fromEnvironment",
           "markdownDescription": "Defines where `mypy` is imported from. This setting may be ignored if `mypy-type-checker.path` is set.",
           "enum": [
             "useBundled",

--- a/src/client.ts
+++ b/src/client.ts
@@ -76,8 +76,8 @@ function convertFromWorkspaceConfigToInitializationOptions() {
       path: settings.get('path'),
       ignorePatterns: settings.get<string[]>('ignorePatterns', []),
       interpreter: settings.get('interpreter'),
-      //importStrategy: settings.get<ImportStrategy>(`importStrategy`) ?? 'fromEnvironment',
-      importStrategy: settings.get<string>('importStrategy', 'useBundled'),
+      // MEMO: In coc-mypy, importStrategy defaults to fromEnvironment. Does not work correctly with "useBundled"
+      importStrategy: settings.get<string>('importStrategy', 'fromEnvironment'),
       showNotifications: settings.get<string>('showNotifications', 'off'),
       extraPaths: [],
       reportingScope: settings.get<string>('reportingScope', 'file'),


### PR DESCRIPTION
We had been using mypy as the default because dmypy was not working properly with the previous language server update.

Since the language server included in vscode-mypy v2023.6.0 was confirmed to work properly, the default was changed to work with dmypy.